### PR TITLE
Update installation steps

### DIFF
--- a/02.installation/01.setup-instructions/docs.md
+++ b/02.installation/01.setup-instructions/docs.md
@@ -56,7 +56,7 @@ If you are upgrading from our old version and encountering version stuck or this
 ```
 file /usr/bin/replication-manager-cli from install of replication-manager-client-3.1.xx-1.x86_64 conflicts with file from package replication-manager-pro-1730721861:2.3.53-1.x86_64
 ```
-It's likely due to our adoption of nfpm which ease our burden for package release, since epoch was not supported.
+It's likely due to our removal of epoch from our newest packages.
 As you can see in the error message replication-manager-client-3.1 does not contains any epoch, while replication-manager-pro 2.3 contains epoch 1730721861
 
 You can solve it by doing these steps:

--- a/02.installation/01.setup-instructions/docs.md
+++ b/02.installation/01.setup-instructions/docs.md
@@ -9,11 +9,9 @@ taxonomy:
 
 For convenience, we provide packages for Debian/Ubuntu and Centos/RHEL and derivatives.
 
-As of today we build portable binary tarballs, Debian Jessie, Ubuntu, CentOS 6 & 7 packages.
-
 Check out [GitHub Releases](https://github.com/signal18/replication-manager/releases) for official releases.
 
-Development builds are also available on our [Continuous Integration Server](http://ci.signal18.io/mrm/builds/)
+Development builds are also available on our [Continuous Integration Server](http://ci.signal18.io/mrm/builds/tags/)
 
 ### Packages, binary naming convention
 
@@ -42,27 +40,33 @@ And a command line client binary **replication-manager-cli** that is requesting 
 Configure the repository as such:
 
 ```
-# /etc/yum.repos.d/signal18.repo
+cat>/etc/yum.repos.d/signal18.repo <<'EOL'
 [signal18]
 name=Signal18 repositories
-baseurl=http://repo.signal18.io/centos/$releasever/$basearch/
+baseurl=http://repo.signal18.io/centos/${releasever}/${basearch}/3.1/
 gpgcheck=0
 enabled=1
+EOL
 ```
 then
 
 `yum install replication-manager-osc`
 
-For last release candidate
+If you are upgrading from our old version and encountering version stuck or this error :
+```
+file /usr/bin/replication-manager-cli from install of replication-manager-client-3.1.xx-1.x86_64 conflicts with file from package replication-manager-pro-1730721861:2.3.53-1.x86_64
+```
+It's likely due to our adoption of nfpm which ease our burden for package release, since epoch was not supported.
+As you can see in the error message replication-manager-client-3.1 does not contains any epoch, while replication-manager-pro 2.3 contains epoch 1730721861
 
-```
-# /etc/yum.repos.d/signal18.repo
-[signal18]
-name=Signal18 repositories
-baseurl=http://repo.signal18.io/centos/2.1/$releasever/$basearch/
-gpgcheck=0
-enabled=1
-```
+You can solve it by doing these steps:
+1. Stop your replication-manager service
+2. Backup your config files which stored in /var/lib/replication-manager/ and /etc/replication-manager to safe place 
+3. Uninstall all of the replication-manager previous installation (pro, osc, and client)
+4. Clean cached metadata for replication-manager repo
+`sudo dnf clean metadata --disablerepo="*" --enablerepo=signal18`
+5. Update the repository to the latest configuration (branch 3.1 is recommended since it's contains the latest update)
+6. Install the new version you want to install
 
 #### Debian/Ubuntu
 
@@ -70,16 +74,10 @@ Create the repo file, install the key and install the binaries as such:
 
 ```
 # change next line with desired version number
-<<<<<<< HEAD
-version="2.1"
-echo "deb [arch=amd64] http://repo.signal18.io/deb $(lsb_release -sc) $version" > /etc/apt/sources.list.d/signal18.list
-apt-key adv --recv-keys --keyserver keyserver.ubuntu.com FAE20E50
-=======
-version="2.3"
+version="3.1"
 gpg --recv-keys --keyserver keyserver.ubuntu.com FAE20E50
 gpg --export FAE20E50 > /etc/apt/trusted.gpg.d/signal18.gpg
 echo "deb [signed-by=/etc/apt/trusted.gpg.d/signal18.gpg] http://repo.signal18.io/deb $(lsb_release -sc) $version" > /etc/apt/sources.list.d/signal18.list
->>>>>>> f8f2f9f82d7e71cfe36cb19701a3eb0152770277
 apt-get update
 apt-get install replication-manager-osc
 ```

--- a/02.installation/01.setup-instructions/docs.md
+++ b/02.installation/01.setup-instructions/docs.md
@@ -67,6 +67,7 @@ You can solve it by doing these steps:
 `sudo dnf clean metadata --disablerepo="*" --enablerepo=signal18`
 5. Update the repository to the latest configuration (branch 3.1 is recommended since it's contains the latest update)
 6. Install the new version you want to install
+7. After the upgrade, review your configuration files to ensure they weren’t replaced. Restore previous settings if any changes occurred unintentionally 
 
 #### Debian/Ubuntu
 

--- a/05.configuration/06.routing/01.proxysql/docs.md
+++ b/05.configuration/06.routing/01.proxysql/docs.md
@@ -78,8 +78,16 @@ taxonomy:
 | Type | String |
 | Default Value | true|
 
+##### <span id="proxysql-bootstrap-users"></span> `proxysql-bootstrap-users` (2.3)
 
-##### `proxysql-copy-grants` (2.0)
+| Item | Value |
+| ---- | ----- |
+| Description | Auto push users when they are discovered |
+| Type | String |
+| Default Value |true |
+
+
+##### `proxysql-copy-grants` (2.0) `obsolete` use [`proxysql-bootstrap-users`](#proxysql-bootstrap-users)
 
 | Item | Value |
 | ---- | ----- |


### PR DESCRIPTION
This pull request updates the installation and configuration documentation to reflect recent changes in package versions and repository structure, and adds important upgrade instructions for users migrating from older versions. It also introduces a new configuration parameter for ProxySQL user bootstrapping and marks an older parameter as obsolete.

**Documentation updates for installation and upgrades:**

* Updated CentOS/YUM repository instructions to use the new `3.1` branch in the `baseurl` and provided a more robust method for creating the repo file. Added detailed upgrade instructions for users encountering version conflicts due to the removal of the epoch in package versions, including steps for safe upgrade and configuration backup.
* Updated Debian/Ubuntu installation instructions to use version `3.1`, modernized GPG key handling, and removed merge conflict artifacts.
* Clarified that development builds are now available at a new URL (`/builds/tags/`) and removed outdated references to older distributions and binary tarballs.

**ProxySQL configuration documentation:**

* Added documentation for the new `proxysql-bootstrap-users` parameter (introduced in version 2.3) for automatically pushing users, and marked the older `proxysql-copy-grants` parameter as obsolete, directing users to the new option.